### PR TITLE
Add all pre-release versions to TS peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "typescript": "2.1.0-dev.20161028"
   },
   "peerDependencies": {
-    "typescript": "*"
+    "typescript": "* || > 1.6.0-dev || > 1.7.0-dev || > 1.8.0-dev || > 1.9.0-dev || > 2.0.0-dev || > 2.1.0-dev || > 2.2.0-dev"
   }
 }


### PR DESCRIPTION
Here's a gross way to address the `npm 2.x` issue in #1. It's causing some people to be unable to install `atom-typescript` due to a recent change to `byots` I made.

https://github.com/TypeStrong/atom-typescript/issues/1115
